### PR TITLE
feat: /contentsページをNotion DB駆動に刷新 + 共通コンポーネント抽出

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ next-env.d.ts
 
 # visitor count data
 /data/
+
+# Playwright MCP logs
+.playwright-mcp/
+
+# Screenshots
+*-screenshot.png

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,4 +1,3 @@
-
 # whether to use the project's gitignore file to ignore files
 # Added on 2025-04-07
 ignore_all_files_in_gitignore: true
@@ -126,3 +125,12 @@ encoding: utf-8
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
 languages:
 - typescript
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,39 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'images.unsplash.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'i.ytimg.com',
+        pathname: '/vi/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'is1-ssl.mzstatic.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'statics.tver.jp',
+      },
+      {
+        protocol: 'https',
+        hostname: 'radiko.jp',
+      },
+      {
+        protocol: 'https',
+        hostname: 'program-static.cf.radiko.jp',
+      },
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'image-cdn-ak.spotifycdn.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'i1.sndcdn.com',
+      },
     ],
   },
 };

--- a/src/app/contents/page.tsx
+++ b/src/app/contents/page.tsx
@@ -1,0 +1,85 @@
+import { getContents } from "@/lib/notion";
+import { fetchContentMetadata } from "@/lib/metadata";
+import type { ContentEntry } from "@/lib/notion";
+import { PageLayout, ContentFrame } from "@/components/PageLayout";
+import ContentsView from "@/components/ContentsView";
+
+export const revalidate = 3600;
+
+// YouTubeのURL各パターンからvideo IDを抽出
+function extractYouTubeId(url: string): string | null {
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=)([a-zA-Z0-9_-]+)/,
+    /(?:youtu\.be\/)([a-zA-Z0-9_-]+)/,
+    /(?:youtube\.com\/live\/)([a-zA-Z0-9_-]+)/,
+    /(?:music\.youtube\.com\/watch\?v=)([a-zA-Z0-9_-]+)/,
+  ];
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+function isUrl(s: string): boolean {
+  return /^https?:\/\//.test(s);
+}
+
+async function enrichEntry(entry: ContentEntry): Promise<ContentEntry> {
+  let { title, url, imageUrl } = entry;
+
+  if (!url && title && isUrl(title)) {
+    url = title;
+  }
+
+  if (!url) return entry;
+
+  const needsTitle = !title || isUrl(title);
+  const needsImage = !imageUrl;
+
+  if (!needsTitle && !needsImage) return { ...entry, url } as ContentEntry;
+
+  if (needsImage) {
+    const ytId = extractYouTubeId(url);
+    if (ytId) {
+      imageUrl = `https://i.ytimg.com/vi/${ytId}/mqdefault.jpg`;
+      if (!needsTitle) return { ...entry, url, imageUrl };
+    }
+  }
+
+  if (needsTitle || !imageUrl) {
+    try {
+      const meta = await fetchContentMetadata(url);
+      if (meta) {
+        if (needsTitle && meta.title) title = meta.title;
+        if (!imageUrl && meta.thumbnailUrl) imageUrl = meta.thumbnailUrl;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  return { ...entry, title: title || url, url, imageUrl };
+}
+
+export default async function ContentsPage() {
+  const rawContents = await getContents();
+
+  const contents: ContentEntry[] = [];
+  for (let i = 0; i < rawContents.length; i += 5) {
+    const batch = await Promise.all(
+      rawContents.slice(i, i + 5).map(enrichEntry)
+    );
+    contents.push(...batch);
+  }
+
+  return (
+    <PageLayout title="コンテンツ" maxWidth={9999}>
+      <div style={{ margin: "0 44px" }}>
+        <ContentFrame>
+          <ContentsView entries={contents} />
+        </ContentFrame>
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -190,6 +190,12 @@ th {
   }
 }
 
+/* VideoCard hover */
+.video-card:hover {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+}
+
 /* アイコン用のレスポンシブ対応 */
 @media (max-width: 600px) {
   .header-icons {

--- a/src/components/BookShelf.tsx
+++ b/src/components/BookShelf.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Tabs, Modal, Text, Badge, Group, Stack, Button } from "@mantine/core";
 import { IconExternalLink } from "@tabler/icons-react";
 import type { Book, BookCategory } from "@/lib/types";
+import { PageLayout, ContentFrame, SectionHeader } from "@/components/PageLayout";
 
 interface BookShelfProps {
   books: Book[];
@@ -282,124 +283,47 @@ export default function BookShelf({ books }: BookShelfProps) {
   };
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        background: "linear-gradient(180deg, #f8f9fa 0%, #f0f1f3 100%)",
-        padding: "24px var(--body-padding)",
-        margin: "calc(-1 * var(--body-padding))",
-      }}
-    >
-      <div style={{ maxWidth: 800, margin: "0 auto", padding: "0 16px" }}>
-        {/* ヘッダー */}
-        <h1
-          style={{
-            textAlign: "center",
+    <PageLayout title="本棚">
+      {/* タブ */}
+      <Tabs
+        value={activeTab}
+        onChange={(value) => setActiveTab((value ?? "一般") as BookCategory)}
+        mb="lg"
+        styles={{
+          list: {
+            borderBottom: "2px solid #868e96",
+          },
+          tab: {
+            color: "#495057",
+            fontWeight: 600,
             fontFamily: "'Noto Sans JP', sans-serif",
-            fontSize: 28,
-            fontWeight: 700,
-            color: "#2d3436",
-            margin: "0 0 24px",
-            letterSpacing: "0.05em",
-          }}
-        >
-          本棚
-        </h1>
-
-        {/* タブ */}
-        <Tabs
-          value={activeTab}
-          onChange={(value) => setActiveTab((value ?? "一般") as BookCategory)}
-          mb="lg"
-          styles={{
-            list: {
-              borderBottom: "2px solid #868e96",
+            "&[data-active]": {
+              color: "#495057",
+              borderColor: "#495057",
+              backgroundColor: "rgba(73, 80, 87, 0.08)",
             },
-            tab: {
-              color: "#495057",
-              fontWeight: 600,
-              fontFamily: "'Noto Sans JP', sans-serif",
-              "&[data-active]": {
-                color: "#495057",
-                borderColor: "#495057",
-                backgroundColor: "rgba(73, 80, 87, 0.08)",
-              },
-              "&:hover": {
-                backgroundColor: "rgba(73, 80, 87, 0.04)",
-              },
+            "&:hover": {
+              backgroundColor: "rgba(73, 80, 87, 0.04)",
             },
-          }}
-        >
-          <Tabs.List>
-            <Tabs.Tab value="一般">一般 ({counts["一般"]})</Tabs.Tab>
-            <Tabs.Tab value="技術書">技術書 ({counts["技術書"]})</Tabs.Tab>
-          </Tabs.List>
-        </Tabs>
+          },
+        }}
+      >
+        <Tabs.List>
+          <Tabs.Tab value="一般">一般 ({counts["一般"]})</Tabs.Tab>
+          <Tabs.Tab value="技術書">技術書 ({counts["技術書"]})</Tabs.Tab>
+        </Tabs.List>
+      </Tabs>
 
-        {/* 本棚フレーム */}
-        <div
-          style={{
-            border: "6px solid #dee2e6",
-            background: "linear-gradient(180deg, #ffffff 0%, #fafafa 100%)",
-            borderRadius: "12px",
-            boxShadow: "0 2px 12px rgba(0,0,0,0.08), inset 0 0 20px rgba(0,0,0,0.03)",
-          }}
-        >
-          {/* 読書中 / 未読 セクション */}
-          <div
-            style={{
-              fontFamily: "'Noto Sans JP', sans-serif",
-              fontSize: 14,
-              fontWeight: 600,
-              color: "#495057",
-              padding: "12px 24px 0",
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-            }}
-          >
-            <span
-              style={{
-                display: "inline-block",
-                width: 4,
-                height: 18,
-                backgroundColor: "#2196F3",
-                borderRadius: 2,
-              }}
-            />
-            読書中 / 未読
-          </div>
-          <ShelfSection books={activeBooks} onBookClick={setSelectedBook} />
+      {/* 本棚フレーム */}
+      <ContentFrame>
+        <SectionHeader label="読書中 / 未読" color="#2196F3" />
+        <ShelfSection books={activeBooks} onBookClick={setSelectedBook} />
 
-          {/* 読了 セクション */}
-          <div
-            style={{
-              fontFamily: "'Noto Sans JP', sans-serif",
-              fontSize: 14,
-              fontWeight: 600,
-              color: "#495057",
-              padding: "16px 24px 0",
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-            }}
-          >
-            <span
-              style={{
-                display: "inline-block",
-                width: 4,
-                height: 18,
-                backgroundColor: "#4CAF50",
-                borderRadius: 2,
-              }}
-            />
-            読了
-          </div>
-          <ShelfSection books={finishedBooks} onBookClick={setSelectedBook} />
-        </div>
-      </div>
+        <SectionHeader label="読了" color="#4CAF50" paddingTop="16px" />
+        <ShelfSection books={finishedBooks} onBookClick={setSelectedBook} />
+      </ContentFrame>
 
       <BookDetailModal book={selectedBook} onClose={() => setSelectedBook(null)} />
-    </div>
+    </PageLayout>
   );
 }

--- a/src/components/ContentsView.tsx
+++ b/src/components/ContentsView.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useState } from "react";
+import { Modal, Button } from "@mantine/core";
+import { IconExternalLink } from "@tabler/icons-react";
+import type { ContentEntry, ContentMedia } from "@/lib/notion";
+import { SectionHeader } from "@/components/PageLayout";
+
+const MEDIA_COLORS: Record<ContentMedia, string> = {
+  Youtube: "#FF0000",
+  Podcast: "#9933CC",
+  PrimeVideo: "#00A8E1",
+  TVer: "#00B900",
+  ラジオ: "#00A0E9",
+  Music: "#1DB954",
+  記事: "#3EA8FF",
+  SpeakerDeck: "#009287",
+  note: "#41C9B4",
+  書籍: "#8B4513",
+};
+
+const MEDIA_LABELS: Record<ContentMedia, string> = {
+  Youtube: "YouTube",
+  Podcast: "Podcast",
+  PrimeVideo: "Prime Video",
+  TVer: "TVer",
+  ラジオ: "ラジオ",
+  Music: "Music",
+  記事: "記事",
+  SpeakerDeck: "Speaker Deck",
+  note: "note",
+  書籍: "書籍",
+};
+
+function getWeekStart(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00");
+  const day = d.getDay();
+  const diff = day === 0 ? 6 : day - 1;
+  d.setDate(d.getDate() - diff);
+  return d.toISOString().split("T")[0];
+}
+
+function formatWeekLabel(weekStart: string): string {
+  const start = new Date(weekStart + "T00:00:00");
+  const end = new Date(start);
+  end.setDate(end.getDate() + 6);
+  const fmt = (d: Date) => `${d.getMonth() + 1}/${d.getDate()}`;
+  return `${start.getFullYear()}年 ${fmt(start)} 〜 ${fmt(end)}`;
+}
+
+function MediaBadge({ media, size = "sm" }: { media: ContentMedia; size?: "sm" | "md" }) {
+  const isMd = size === "md";
+  return (
+    <span
+      style={{
+        fontSize: isMd ? "11px" : "9px",
+        fontWeight: 600,
+        color: "#fff",
+        backgroundColor: MEDIA_COLORS[media] ?? "#868e96",
+        borderRadius: isMd ? 4 : 3,
+        padding: isMd ? "1px 8px" : "0px 4px",
+        lineHeight: 1.6,
+      }}
+    >
+      {MEDIA_LABELS[media] ?? media}
+    </span>
+  );
+}
+
+function ContentCard({ item, onClick }: { item: ContentEntry; onClick: () => void }) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        display: "block",
+        width: 192,
+        flexShrink: 0,
+        cursor: "pointer",
+      }}
+    >
+      <div
+        className="video-card"
+        style={{
+          borderRadius: 8,
+          overflow: "hidden",
+          backgroundColor: "#fff",
+          boxShadow: "0 2px 8px rgba(0,0,0,0.08)",
+          transition: "transform 0.2s ease, box-shadow 0.2s ease",
+        }}
+      >
+        {item.imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={item.imageUrl}
+            alt={item.title}
+            width={192}
+            height={108}
+            style={{
+              display: "block",
+              width: "100%",
+              height: 108,
+              objectFit: "cover",
+            }}
+          />
+        ) : (
+          <div
+            style={{
+              width: "100%",
+              height: 108,
+              backgroundColor: "#e9ecef",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <span style={{ fontSize: 20, color: "#adb5bd" }}>🎬</span>
+          </div>
+        )}
+        <div style={{ padding: "5px 8px 6px" }}>
+          <p
+            style={{
+              margin: 0,
+              fontSize: "11px",
+              fontWeight: 700,
+              fontFamily: "'Noto Sans JP', sans-serif",
+              color: "#2d3436",
+              lineHeight: 1.4,
+              height: "calc(11px * 1.4 * 2)",
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+            }}
+          >
+            {item.title}
+          </p>
+          <div style={{ marginTop: 3, display: "flex", alignItems: "center", gap: 4 }}>
+            <MediaBadge media={item.media} />
+            {item.date && (
+              <span style={{ fontSize: "9px", color: "#868e96" }}>{item.date}</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ContentDetailModal({
+  item,
+  onClose,
+}: {
+  item: ContentEntry | null;
+  onClose: () => void;
+}) {
+  if (!item) return null;
+
+  return (
+    <Modal
+      opened={!!item}
+      onClose={onClose}
+      title={item.title}
+      centered
+      size="lg"
+      lockScroll={false}
+      styles={{ title: { fontWeight: 700, fontSize: "18px" } }}
+    >
+      {item.imageUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={item.imageUrl}
+          alt={item.title}
+          style={{
+            width: "100%",
+            maxHeight: 360,
+            objectFit: "cover",
+            borderRadius: 8,
+          }}
+        />
+      ) : (
+        <div
+          style={{
+            width: "100%",
+            height: 200,
+            backgroundColor: "#e9ecef",
+            borderRadius: 8,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <span style={{ fontSize: 40, color: "#adb5bd" }}>🎬</span>
+        </div>
+      )}
+
+      <div style={{ marginTop: 12, display: "flex", alignItems: "center", gap: 8 }}>
+        <MediaBadge media={item.media} size="md" />
+        {item.date && (
+          <span style={{ fontSize: "13px", color: "#868e96" }}>{item.date}</span>
+        )}
+      </div>
+
+      {item.body && (
+        <div
+          style={{
+            marginTop: 16,
+            fontSize: "14px",
+            fontFamily: "'Noto Sans JP', sans-serif",
+            color: "#2d3436",
+            lineHeight: 1.8,
+            whiteSpace: "pre-wrap",
+          }}
+        >
+          {item.body}
+        </div>
+      )}
+
+      {item.url && (
+        <Button
+          component="a"
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          variant="light"
+          size="sm"
+          leftSection={<IconExternalLink size={16} />}
+          mt="lg"
+          fullWidth
+        >
+          コンテンツを見る
+        </Button>
+      )}
+    </Modal>
+  );
+}
+
+interface ContentsViewProps {
+  entries: ContentEntry[];
+}
+
+export default function ContentsView({ entries }: ContentsViewProps) {
+  const [selected, setSelected] = useState<ContentEntry | null>(null);
+
+  // 週単位でグループ化
+  const grouped = new Map<string, ContentEntry[]>();
+  for (const entry of entries) {
+    const key = entry.date ? getWeekStart(entry.date) : "undated";
+    const list = grouped.get(key) || [];
+    list.push(entry);
+    grouped.set(key, list);
+  }
+
+  const sections = [...grouped.entries()].sort((a, b) => {
+    if (a[0] === "undated") return 1;
+    if (b[0] === "undated") return -1;
+    return b[0].localeCompare(a[0]);
+  });
+
+  return (
+    <>
+      {sections.map(([weekKey, items]) => {
+        const label =
+          weekKey === "undated" ? "日付なし" : formatWeekLabel(weekKey);
+        return (
+          <div key={weekKey}>
+            <SectionHeader label={label} color="#495057" />
+            <div style={{ padding: "12px 24px 16px", overflowX: "auto" }}>
+              <div style={{ display: "flex", gap: "12px" }}>
+                {items.map((item) => (
+                  <ContentCard
+                    key={item.id}
+                    item={item}
+                    onClick={() => setSelected(item)}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+      {sections.length === 0 && (
+        <div style={{ padding: "24px", textAlign: "center" }}>
+          <p
+            style={{
+              fontFamily: "'Noto Sans JP', sans-serif",
+              color: "#868e96",
+              fontStyle: "italic",
+            }}
+          >
+            コンテンツがありません
+          </p>
+        </div>
+      )}
+      <ContentDetailModal item={selected} onClose={() => setSelected(null)} />
+    </>
+  );
+}

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,0 +1,88 @@
+interface PageLayoutProps {
+  title: string;
+  maxWidth?: number;
+  children: React.ReactNode;
+}
+
+export function PageLayout({ title, maxWidth = 800, children }: PageLayoutProps) {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "linear-gradient(180deg, #f8f9fa 0%, #f0f1f3 100%)",
+        padding: "24px var(--body-padding)",
+        margin: "calc(-1 * var(--body-padding))",
+      }}
+    >
+      <div style={{ maxWidth, margin: "0 auto", padding: "0 16px" }}>
+        <h1
+          style={{
+            textAlign: "center",
+            fontFamily: "'Noto Sans JP', sans-serif",
+            fontSize: 28,
+            fontWeight: 700,
+            color: "#2d3436",
+            margin: "0 0 24px",
+            letterSpacing: "0.05em",
+          }}
+        >
+          {title}
+        </h1>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+interface ContentFrameProps {
+  children: React.ReactNode;
+}
+
+export function ContentFrame({ children }: ContentFrameProps) {
+  return (
+    <div
+      style={{
+        border: "6px solid #dee2e6",
+        background: "linear-gradient(180deg, #ffffff 0%, #fafafa 100%)",
+        borderRadius: "12px",
+        boxShadow: "0 2px 12px rgba(0,0,0,0.08), inset 0 0 20px rgba(0,0,0,0.03)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface SectionHeaderProps {
+  label: string;
+  color: string;
+  paddingTop?: string;
+}
+
+export function SectionHeader({ label, color, paddingTop = "12px" }: SectionHeaderProps) {
+  return (
+    <div
+      style={{
+        fontFamily: "'Noto Sans JP', sans-serif",
+        fontSize: 14,
+        fontWeight: 600,
+        color: "#495057",
+        padding: `${paddingTop} 24px 0`,
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+      }}
+    >
+      <span
+        style={{
+          display: "inline-block",
+          width: 4,
+          height: 18,
+          backgroundColor: color,
+          borderRadius: 2,
+        }}
+      />
+      {label}
+    </div>
+  );
+}

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,0 +1,152 @@
+export interface ContentItem {
+  url: string;
+  title: string;
+  description: string;
+  thumbnailUrl: string;
+}
+
+interface OEmbedResponse {
+  title?: string;
+  author_name?: string;
+  thumbnail_url?: string;
+}
+
+// oEmbed endpoints for supported services
+const OEMBED_ENDPOINTS: Record<string, string> = {
+  "youtube.com": "https://www.youtube.com/oembed?format=json&url=",
+  "youtu.be": "https://www.youtube.com/oembed?format=json&url=",
+  "music.youtube.com": "https://www.youtube.com/oembed?format=json&url=",
+  "open.spotify.com": "https://open.spotify.com/oembed?url=",
+  "soundcloud.com": "https://soundcloud.com/oembed?format=json&url=",
+};
+
+// Sites that require bot UA for OGP (SPA that renders OGP only for crawlers)
+const BOT_UA_HOSTS = new Set(["tver.jp"]);
+
+const BROWSER_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const BOT_UA = "facebookexternalhit/1.1";
+
+function getHost(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "";
+  }
+}
+
+const FETCH_TIMEOUT = 8000;
+
+async function fetchWithTimeout(
+  input: string,
+  init?: RequestInit
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchViaOEmbed(
+  oembedEndpoint: string,
+  url: string
+): Promise<ContentItem | null> {
+  try {
+    const res = await fetchWithTimeout(oembedEndpoint + encodeURIComponent(url));
+    if (!res.ok) return null;
+    const data: OEmbedResponse = await res.json();
+    return {
+      url,
+      title: data.title || "",
+      description: data.author_name || "",
+      thumbnailUrl: data.thumbnail_url || "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function extractOgTag(html: string, property: string): string {
+  // Match both property="og:xxx" content="..." and content="..." property="og:xxx"
+  const patterns = [
+    new RegExp(
+      `<meta[^>]+property=["']${property}["'][^>]+content=["']([^"']+)["']`,
+      "i"
+    ),
+    new RegExp(
+      `<meta[^>]+content=["']([^"']+)["'][^>]+property=["']${property}["']`,
+      "i"
+    ),
+  ];
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match) return match[1];
+  }
+  return "";
+}
+
+function extractTitle(html: string): string {
+  const match = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+  return match ? match[1].trim() : "";
+}
+
+async function fetchViaOgp(url: string): Promise<ContentItem | null> {
+  const host = getHost(url);
+  const ua = BOT_UA_HOSTS.has(host) ? BOT_UA : BROWSER_UA;
+
+  try {
+    const res = await fetchWithTimeout(url, {
+      headers: { "User-Agent": ua },
+      redirect: "follow",
+    });
+    if (!res.ok) return null;
+    const html = await res.text();
+
+    const ogTitle = extractOgTag(html, "og:title");
+    const ogImage = extractOgTag(html, "og:image");
+    const ogDescription = extractOgTag(html, "og:description");
+    const title = ogTitle || extractTitle(html);
+
+    if (!title && !ogImage) return null;
+
+    return {
+      url,
+      title: title || "",
+      description: ogDescription || "",
+      thumbnailUrl: ogImage || "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchContentMetadata(
+  url: string
+): Promise<ContentItem | null> {
+  const host = getHost(url);
+
+  // Check oEmbed first
+  for (const [domain, endpoint] of Object.entries(OEMBED_ENDPOINTS)) {
+    if (host.includes(domain)) {
+      return fetchViaOEmbed(endpoint, url);
+    }
+  }
+
+  // Fallback to OGP scraping
+  return fetchViaOgp(url);
+}
+
+export async function fetchMultipleContent(
+  urls: string[]
+): Promise<ContentItem[]> {
+  const results = await Promise.allSettled(urls.map(fetchContentMetadata));
+  return results
+    .filter(
+      (r): r is PromiseFulfilledResult<ContentItem> =>
+        r.status === "fulfilled" && r.value !== null
+    )
+    .map((r) => r.value);
+}

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -218,6 +218,80 @@ export async function getBooks(): Promise<Book[]> {
   return books;
 }
 
+export type ContentMedia = "Youtube" | "Podcast" | "PrimeVideo" | "TVer" | "ラジオ" | "Music" | "記事" | "note" | "書籍" | "SpeakerDeck";
+
+export interface ContentEntry {
+  id: string;
+  title: string;
+  url: string | null;
+  imageUrl: string | null;
+  media: ContentMedia;
+  date: string | null;
+  body: string;
+}
+
+/**
+ * 摂取記録DBからコンテンツ一覧を取得（公開のみ）
+ */
+export async function getContents(): Promise<ContentEntry[]> {
+  const databaseId = process.env.NOTION_CONTENTS_DATABASE_ID;
+
+  if (!databaseId) {
+    console.warn('NOTION_CONTENTS_DATABASE_ID not configured, returning empty contents');
+    return [];
+  }
+
+  const response = await notion.databases.query({
+    database_id: databaseId,
+    filter: {
+      property: '公開',
+      checkbox: {
+        equals: true,
+      },
+    },
+    sorts: [
+      {
+        property: '日付',
+        direction: 'descending',
+      },
+    ],
+  });
+
+  const entries = await Promise.all(
+    response.results.map(async (result) => {
+      const page = result as PageObjectResponse;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const properties = page.properties as Record<string, any>;
+
+      const title = properties['タイトル']?.title?.[0]?.plain_text || '';
+      const url = properties['URL']?.url || null;
+      const imageUrl = properties['画像URL']?.url || null;
+      const media = (properties['媒体']?.select?.name || '記事') as ContentMedia;
+      const date = properties['日付']?.date?.start || null;
+
+      let body = '';
+      try {
+        const blocks = await notion.blocks.children.list({ block_id: page.id, page_size: 100 });
+        body = (blocks.results as BlockObjectResponse[])
+          .map((block) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const b = block as any;
+            const richTexts = b[block.type]?.rich_text || [];
+            return richTexts.map((t: { plain_text: string }) => t.plain_text).join('');
+          })
+          .filter(Boolean)
+          .join('\n');
+      } catch {
+        // ignore
+      }
+
+      return { id: page.id, title, url, imageUrl, media, date, body };
+    })
+  );
+
+  return entries;
+}
+
 /**
  * ブロックから最初の画像URLを抽出
  * @param blocks - Notion blocks

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,6 +35,14 @@ export interface Timer {
   targetTime?: number;
 }
 
+export interface YouTubeVideo {
+  id: string;
+  title: string;
+  channelName: string;
+  channelUrl: string;
+  thumbnailUrl: string;
+}
+
 export type BookStatus = "未読" | "読書中" | "読了";
 export type BookCategory = "一般" | "技術書";
 

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -1,0 +1,61 @@
+import { YouTubeVideo } from "@/lib/types";
+
+interface OEmbedResponse {
+  title: string;
+  author_name: string;
+  author_url: string;
+  thumbnail_url: string;
+}
+
+function extractVideoId(url: string): string | null {
+  // https://www.youtube.com/watch?v=VIDEO_ID
+  // https://youtu.be/VIDEO_ID
+  // https://youtu.be/VIDEO_ID?si=...
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=)([a-zA-Z0-9_-]+)/,
+    /(?:youtu\.be\/)([a-zA-Z0-9_-]+)/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+export async function fetchYouTubeMetadata(
+  videoUrl: string
+): Promise<YouTubeVideo | null> {
+  const videoId = extractVideoId(videoUrl);
+  if (!videoId) return null;
+
+  try {
+    const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(videoUrl)}&format=json`;
+    const res = await fetch(oembedUrl);
+    if (!res.ok) return null;
+
+    const data: OEmbedResponse = await res.json();
+
+    return {
+      id: videoId,
+      title: data.title,
+      channelName: data.author_name,
+      channelUrl: data.author_url,
+      thumbnailUrl: `https://i.ytimg.com/vi/${videoId}/mqdefault.jpg`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchMultipleVideos(
+  urls: string[]
+): Promise<YouTubeVideo[]> {
+  const results = await Promise.allSettled(urls.map(fetchYouTubeMetadata));
+  return results
+    .filter(
+      (r): r is PromiseFulfilledResult<YouTubeVideo> =>
+        r.status === "fulfilled" && r.value !== null
+    )
+    .map((r) => r.value);
+}


### PR DESCRIPTION
## 概要

/contentsページをNotion「摂取記録」DB駆動に刷新し、booksページとのデザイン統一のため共通コンポーネントを抽出しました。

## 変更内容

### 共通コンポーネント抽出
- `PageLayout`, `ContentFrame`, `SectionHeader` を `src/components/PageLayout.tsx` に抽出
- `BookShelf.tsx` を共通コンポーネントでリファクタ

### /contentsページ刷新
- Notion「摂取記録」DBから公開フラグ付きエントリを取得
- サムネイル・タイトルの自動取得（oEmbed: YouTube/Spotify/SoundCloud、OGP: Apple Podcasts/TVer/radiko/Zenn/note/SpeakerDeck）
- 手動登録が必要なサービス（Prime Video, x.com等）はNotionで直接入力
- 週単位グルーピング（新しい順）+ 横スクロール表示
- カードクリックでモーダル詳細表示（Notion本文の感想 + 外部リンクボタン）
- 画像なしカード用プレースホルダ

### その他
- `next.config.ts`: 外部画像ドメイン追加
- `globals.css`: `.video-card:hover` スタイル追加
- `.gitignore`: Playwright logs, screenshots除外

## 環境変数
```
NOTION_CONTENTS_DATABASE_ID=2f3fe3f55f9a807887d8fa6baa3e9957
```
Vercelにも設定が必要です。